### PR TITLE
hotfix(auth): fix server side auth validation

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -39,8 +39,8 @@ export async function middleware(request: NextRequest, response: NextResponse) {
     }
   );
 
-  // We need to use `getUser` here because `getSession` does not gurantee to revalidate the auth token
-  // and session could be spoofed by anyone
+  // We need to use `getUser` here because `getSession` does not guarantee to revalidate the auth token,
+  // and anyone could spoof the session.
   const {
     data: { user },
   } = await supabase.auth.getUser();


### PR DESCRIPTION
When setting up supabase for another project, I just discovered inside the supabase docs the mentions regarding `getSession` vs. `getUser`. This is probably linked to the showcase with Lukas this week when you were locked in and, after navigating (and probably revalidating the session client side), got redirected to login.


